### PR TITLE
feat: add ability to use a json config file for env vars and bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,14 @@ This is particularly useful where you don't have control over the environment, i
     os.environ[CONDUCTOR_AUTH_KEY] = '<YOUR_APPLICATION_AUTH_KEY>'
     os.environ[CONDUCTOR_AUTH_SECRET] = '<YOUR_APPLICATION_SECRET_KEY>'
 ```
-To run with local development add 'local_dev' to the server arguments:
+To run with local development add '--local_dev' to the server arguments:
 ```commandline
-uv run server.py local_dev
+uv run server.py --local_dev
 ```
 > Note: the `/api` path is required as part of the CONDUCTOR_SERVER_URL for most applications
 # Adding to Claude
 Follow [this tutorial](https://modelcontextprotocol.io/quickstart/user) for adding the mcp server to claude, and use the following
-configuration, with or without the `local_dev` argument:
+configuration, with or without the `--local_dev` argument:
 ```json
 {
   "mcpServers": {
@@ -50,7 +50,7 @@ configuration, with or without the `local_dev` argument:
         "/<YOUR ABSOLUTE PATH TO THE DIRECTORY CONTAINING server.py>",
         "run",
         "server.py",
-        "local_dev"
+        "--local_dev"
       ]
     }
   }
@@ -65,19 +65,33 @@ If you installed the package globally, i.e. from pypi:
 ```commandline
 pip install conductor-mcp
 ```
-then you can point to the system install in your Claude config:
+then you can point to the system install in your Claude config, but first you must create a json config file for your conductor values:
 
+```json
+{
+  "CONDUCTOR_SERVER_URL": "https://developer.orkescloud.com/api",
+  "CONDUCTOR_AUTH_KEY": "<YOUR_APPLICATION_AUTH_KEY>",
+  "CONDUCTOR_AUTH_SECRET": "<YOUR_APPLICATION_SECRET_KEY>"
+}
+```
+Claude config:
 ```json
 {
   "mcpServers": {
     "conductor": {
       "command": "conductor-mcp",
       "args": [
-        "local_dev"
+        "--config",
+        "<ABSOLUTE PATH TO A JSON CONFIG FILE>"
       ]
     }
   }
 }
+```
+
+You can also just the server from the command line on its own after installing through pip:
+```commandline
+conductor-mcp --config YOUR_CONFIG_FILE
 ```
 
 

--- a/conductor_mcp/server.py
+++ b/conductor_mcp/server.py
@@ -6,22 +6,56 @@
 #  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 #  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 #  specific language governing permissions and limitations under the License.
+import json
+import os
 
 from fastmcp import FastMCP
+from pygments.lexer import default
 
 from conductor_mcp import local_development
 from conductor_mcp.tools.task import task_mcp
 from conductor_mcp.tools.workflow import workflow_mcp
-import sys
+import click
+
+from conductor_mcp.utils.constants import CONDUCTOR_SERVER_URL, CONDUCTOR_AUTH_KEY, CONDUCTOR_AUTH_SECRET
 
 mcp = FastMCP("oss-conductor")
 mcp.mount("workflow", workflow_mcp)
 mcp.mount("task", task_mcp)
 
 
-def run():
-    if "local_dev" in sys.argv:
+@click.command()
+@click.option(
+    "--local_dev",
+    "-l",
+    is_flag=True,
+    help="Used when the running code directly (i.e. git clone), set Conductor variables in the local_development.py file when using this option.",
+)
+@click.option(
+    "--config",
+    "-c",
+    default=None,
+    help="""
+    The location of a JSON config file containing the Conductor variables:
+{
+    "CONDUCTOR_SERVER_URL": ""https://developer.orkesconductor.io/api"",
+    "CONDUCTOR_AUTH_KEY": "<YOUR_AUTH_KEY>",
+    "CONDUCTOR_AUTH_SECRET": "<YOUR_AUTH_SECRET>"
+}
+""",
+)
+def run(local_dev, config):
+    if local_dev and config is not None:
+        raise click.UsageError("--local_dev and --config are mutually exclusive, please use just one.")
+    elif local_dev:
         local_development.initialize()
+    elif config is not None:
+        print(f"Initializing Conductor with config file: {config}")
+        with open(config, "r") as file:
+            data = json.load(file)
+            os.environ[CONDUCTOR_SERVER_URL] = data[CONDUCTOR_SERVER_URL]
+            os.environ[CONDUCTOR_AUTH_KEY] = data[CONDUCTOR_AUTH_KEY]
+            os.environ[CONDUCTOR_AUTH_SECRET] = data[CONDUCTOR_AUTH_SECRET]
     # Initialize and run the server
     mcp.run(transport="stdio")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,13 +8,14 @@
 #  specific language governing permissions and limitations under the License.
 [project]
 name = "conductor-mcp"
-version = "0.1.3"
+version = "0.1.4"
 description = "MCP server for exposing conductor endpoints."
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "asyncio>=3.4.3",
     "black>=25.1.0",
+    "click>=8.1.8",
     "fastmcp>=2.2.5",
     "freezegun>=1.5.1",
     "httpx>=0.28.1",

--- a/uv.lock
+++ b/uv.lock
@@ -85,11 +85,12 @@ wheels = [
 
 [[package]]
 name = "conductor-mcp"
-version = "0.1.0"
+version = "0.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "asyncio" },
     { name = "black" },
+    { name = "click" },
     { name = "fastmcp" },
     { name = "freezegun" },
     { name = "httpx" },
@@ -102,6 +103,7 @@ dependencies = [
 requires-dist = [
     { name = "asyncio", specifier = ">=3.4.3" },
     { name = "black", specifier = ">=25.1.0" },
+    { name = "click", specifier = ">=8.1.8" },
     { name = "fastmcp", specifier = ">=2.2.5" },
     { name = "freezegun", specifier = ">=1.5.1" },
     { name = "httpx", specifier = ">=0.28.1" },


### PR DESCRIPTION
Since this code can be installed through pip and ran as a command, i.e. `$ conductor-mcp` it's advantageous to allow the ability to create a config file for API keys that can be pointed to from anywhere, i.e. `$ conductor-mcp --config ~/.conductor-mcp/config.json`.

Also updates the readme.

There's a breaking change in that the command line must now use double hyphen for the local_dev flag, `--local_dev`.